### PR TITLE
Change outer ring color of pomodoro timer to red

### DIFF
--- a/app/components/Timer.tsx
+++ b/app/components/Timer.tsx
@@ -88,7 +88,7 @@ const Timer = ({
 						strokeWidth={5}
 						styles={buildStyles({
 							textColor: "#fff",
-							pathColor: "rgb(225, 225, 225)",
+							pathColor: "rgb(255, 0, 0)",
 							trailColor: "rgb(50, 50, 50, 0.6)",
 						})}
 					>


### PR DESCRIPTION
Change the outer ring color of the pomodoro timer from white to red.

* Modify the `pathColor` property in the `buildStyles` function in `app/components/Timer.tsx` to "rgb(255, 0, 0)".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shreyapandeeyy/TASKIFY/pull/1?shareId=d37f1613-17e8-419b-91c1-ec25e44e7821).